### PR TITLE
remove toast message and tests

### DIFF
--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -1,7 +1,6 @@
 import React, {useState} from "react";
 import { Container, CardGroup, Button } from "react-bootstrap";
 import { useParams } from "react-router-dom";
-import { toast } from "react-toastify";
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import CommonsOverview from "main/components/Commons/CommonsOverview";
@@ -105,7 +104,6 @@ export default function PlayPage() {
   // Stryker disable all 
   const mutationsell = useBackendMutation(
     objectToAxiosParamsSell,
-    { onSuccess: onSuccessSell },
     [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
   );
   // Stryker restore all 

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -87,7 +87,8 @@ export default function PlayPage() {
     mutationbuy.mutate(userCommons)
   };
 
-
+const onSuccessSell = () => {
+};
 
   // Stryker disable all 
   const objectToAxiosParamsSell = (newUserCommons) => ({
@@ -104,6 +105,7 @@ export default function PlayPage() {
   // Stryker disable all 
   const mutationsell = useBackendMutation(
     objectToAxiosParamsSell,
+    { onSuccess: onSuccessSell },
     [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
   );
   // Stryker restore all 

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -89,9 +89,6 @@ export default function PlayPage() {
   };
 
 
-  const onSuccessSell = () => {
-    toast(`Cow sold!`);
-  }
 
   // Stryker disable all 
   const objectToAxiosParamsSell = (newUserCommons) => ({

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -94,7 +94,6 @@ describe("PlayPage tests", () => {
 
         await waitFor(() => expect(axiosMock.history.put.length).toBe(2));
 
-        expect(mockToast).toBeCalledWith("Cow sold!");
     });
 
     test("Make sure that both the Announcements and Welcome Farmer components show up", async () => {


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we remove the toast message that pops up when a user sells a cow.

## Media
![ezgif com-video-to-gif (1)](https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-4/assets/25533620/e9c104e5-6e8e-4d36-a551-4a81402d2f8d)


## Feedback Request (Optional)
Please give suggestions on the following:
- The way this is implemented is the best I can think of. Is it acceptable?

## Validation (Optional)
1. Download this branch.
2. Run the project.
3. Go to this page.
4. Test this function.

## Tests
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #14 
