### PR TITLE
Backend for set default values for Commons fields in application.properties / env variables

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -34,8 +34,8 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     const curr = new Date();
     const today = curr.toISOString().split('T')[0];
     const DefaultVals = {
-        name: "", startingBalance: "10000", cowPrice: "100",
-        milkPrice: "1", degradationRate: 0.001, carryingCapacity: 100, startingDate: today
+        name: "", startingBalance: "20000", cowPrice: "200",
+        milkPrice: "2", degradationRate: 0.002, carryingCapacity: 200, startingDate: today
     };
 
     const belowStrategy = initialCommons?.belowCapacityStrategy || healthUpdateStrategies?.defaultBelowCapacity;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -78,6 +79,54 @@ public class CommonsController extends ApiController {
                 .orElseThrow(() -> new EntityNotFoundException(Commons.class, id)));
 
         return commonsPlus;
+    }
+
+    @Value("${app.commons.default.startingBalance}")
+    private double defaultStartingBalance;
+
+    @Value("${app.commons.default.cowPrice}")
+    private double defaultCowPrice;
+
+    @Value("${app.commons.default.milkPrice}")
+    private double defaultMilkPrice;
+
+    @Value("${app.commons.default.degradationRate}")
+    private double defaultDegradationRate;
+
+    @Value("${app.commons.default.carryingCapacity}")
+    private int defaultCarryingCapacity;
+
+    @Value("${app.commons.default.capacityPerUser}")
+    private int defaultCapacityPerUser;
+
+    @Value("${app.commons.default.aboveCapacityHealthUpdateStrategy}")
+    private CowHealthUpdateStrategies defaultAboveCapacityHealthUpdateStrategy;
+
+    @Value("${app.commons.default.belowCapacityHealthUpdateStrategy}")
+    private CowHealthUpdateStrategies defaultBelowCapacityHealthUpdateStrategy;
+
+    @Operation(summary = "Get the default values for a new commons")
+    @GetMapping("/defaults")
+    public ResponseEntity<String> getDefaults() throws JsonProcessingException {
+        log.info("getDefaults()...");
+
+        // Create a Commons object with the values
+        Commons defaults = Commons.builder()
+                                    .startingBalance(defaultStartingBalance)
+                                    .cowPrice(defaultCowPrice)
+                                    .milkPrice(defaultMilkPrice)
+                                    .degradationRate(defaultDegradationRate)
+                                    .carryingCapacity(defaultCarryingCapacity)
+                                    .capacityPerUser(defaultCapacityPerUser)
+                                    .aboveCapacityHealthUpdateStrategy(defaultAboveCapacityHealthUpdateStrategy)
+                                    .belowCapacityHealthUpdateStrategy(defaultBelowCapacityHealthUpdateStrategy)
+                                    .build();
+
+        // Serialize the Commons object to JSON
+        String body = mapper.writeValueAsString(defaults);
+
+        // Return the serialized JSON as the response body
+        return ResponseEntity.ok().body(body);
     }
 
     @Operation(summary = "Update a commons")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,7 +38,7 @@ app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 0 4 * * *}}
 app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0,6,12,18 * * *}}
 spring.jackson.time-zone=America/Los_Angeles
 
-app.commons.default.startingBalance=${HAPPYCOWS_STARTING_BALANCE:${env.HAPPYCOWS_STARTING_BALANCE:1000}}
+app.commons.default.startingBalance=${HAPPYCOWS_STARTING_BALANCE:${env.HAPPYCOWS_STARTING_BALANCE:10000}}
 app.commons.default.cowPrice=${HAPPYCOWS_COW_PRICE:${env.HAPPYCOWS_COW_PRICE:100}}
 app.commons.default.milkPrice=${HAPPYCOWS_MILK_PRICE:${env.HAPPYCOWS_MILK_PRICE:1}}
 app.commons.default.degradationRate=${HAPPYCOWS_DEGRADATION_RATE:${env.HAPPYCOWS_DEGRADATION_RATE:0.001}}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,11 +38,11 @@ app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 0 4 * * *}}
 app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0,6,12,18 * * *}}
 spring.jackson.time-zone=America/Los_Angeles
 
-app.commons.default.startingBalance=${HAPPYCOWS_STARTING_BALANCE:${env.HAPPYCOWS_STARTING_BALANCE:6969}}
-app.commons.default.cowPrice=${HAPPYCOWS_COW_PRICE:${env.HAPPYCOWS_COW_PRICE:696}}
-app.commons.default.milkPrice=${HAPPYCOWS_MILK_PRICE:${env.HAPPYCOWS_MILK_PRICE:6}}
-app.commons.default.degradationRate=${HAPPYCOWS_DEGRADATION_RATE:${env.HAPPYCOWS_DEGRADATION_RATE:0.006}}
-app.commons.default.carryingCapacity=${HAPPYCOWS_CARRYING_CAPACITY:${env.HAPPYCOWS_CARRYING_CAPACITY:600}}
-app.commons.default.capacityPerUser=${HAPPYCOWS_CAPACITY_PER_USER:${env.HAPPYCOWS_CAPACITY_PER_USER:6}}
+app.commons.default.startingBalance=${HAPPYCOWS_STARTING_BALANCE:${env.HAPPYCOWS_STARTING_BALANCE:1000}}
+app.commons.default.cowPrice=${HAPPYCOWS_COW_PRICE:${env.HAPPYCOWS_COW_PRICE:100}}
+app.commons.default.milkPrice=${HAPPYCOWS_MILK_PRICE:${env.HAPPYCOWS_MILK_PRICE:1}}
+app.commons.default.degradationRate=${HAPPYCOWS_DEGRADATION_RATE:${env.HAPPYCOWS_DEGRADATION_RATE:0.001}}
+app.commons.default.carryingCapacity=${HAPPYCOWS_CARRYING_CAPACITY:${env.HAPPYCOWS_CARRYING_CAPACITY:100}}
+app.commons.default.capacityPerUser=${HAPPYCOWS_CAPACITY_PER_USER:${env.HAPPYCOWS_CAPACITY_PER_USER:1}}
 app.commons.default.aboveCapacityHealthUpdateStrategy=${HAPPYCOWS_ABOVE_CAPACITY_HEALTH_UPDATE_STRATEGY:${env.HAPPYCOWS_ABOVE_CAPACITY_HEALTH_UPDATE_STRATEGY:Linear}}
 app.commons.default.belowCapacityHealthUpdateStrategy=${HAPPYCOWS_BELOW_CAPACITY_HEALTH_UPDATE_STRATEGY:${env.HAPPYCOWS_BELOW_CAPACITY_HEALTH_UPDATE_STRATEGY:Constant}}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,3 +38,11 @@ app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 0 4 * * *}}
 app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0,6,12,18 * * *}}
 spring.jackson.time-zone=America/Los_Angeles
 
+app.commons.default.startingBalance=${HAPPYCOWS_STARTING_BALANCE:${env.HAPPYCOWS_STARTING_BALANCE:6969}}
+app.commons.default.cowPrice=${HAPPYCOWS_COW_PRICE:${env.HAPPYCOWS_COW_PRICE:696}}
+app.commons.default.milkPrice=${HAPPYCOWS_MILK_PRICE:${env.HAPPYCOWS_MILK_PRICE:6}}
+app.commons.default.degradationRate=${HAPPYCOWS_DEGRADATION_RATE:${env.HAPPYCOWS_DEGRADATION_RATE:0.006}}
+app.commons.default.carryingCapacity=${HAPPYCOWS_CARRYING_CAPACITY:${env.HAPPYCOWS_CARRYING_CAPACITY:600}}
+app.commons.default.capacityPerUser=${HAPPYCOWS_CAPACITY_PER_USER:${env.HAPPYCOWS_CAPACITY_PER_USER:6}}
+app.commons.default.aboveCapacityHealthUpdateStrategy=${HAPPYCOWS_ABOVE_CAPACITY_HEALTH_UPDATE_STRATEGY:${env.HAPPYCOWS_ABOVE_CAPACITY_HEALTH_UPDATE_STRATEGY:Linear}}
+app.commons.default.belowCapacityHealthUpdateStrategy=${HAPPYCOWS_BELOW_CAPACITY_HEALTH_UPDATE_STRATEGY:${env.HAPPYCOWS_BELOW_CAPACITY_HEALTH_UPDATE_STRATEGY:Constant}}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -21,7 +21,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -33,6 +35,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -1235,6 +1238,28 @@ public class CommonsControllerTests extends ControllerTestCase {
         assertEquals(100, commonsPlus.getEffectiveCapacity());
     }
 
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void getDefaultsTest() throws Exception {
+        Commons commons = Commons.builder()
+                                        .startingBalance(1000)
+                                        .cowPrice(100)
+                                        .milkPrice(1)
+                                        .degradationRate(0.001)
+                                        .carryingCapacity(100) //int
+                                        .capacityPerUser(1)     //int
+                                        .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+                                        .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
+                                        .build();
 
+        MvcResult response = mockMvc.perform(get("/api/commons/defaults").contentType("application/json"))
+                .andExpect(status().isOk()).andReturn();
+
+
+        String responseString = response.getResponse().getContentAsString();
+        String actual = mapper.writeValueAsString(commons);
+
+        assertEquals(actual, responseString);
+    }
 }
 


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we add Commons Create page default values in application.properties as well as the /api/commons/defaults endpoint to return a Commons object with said values.

Implement first part of #12 


## Feedback Request (Optional)
<!--Anywhere specific you want reviewers to take a look at and give suggestions. Delete if not needed.-->
Please give suggestions on the following:
- Having a bunch of private variables with `@Value` annotations doesn't seem like the most elegant way to retrieve values from application.properties, is there a better way to be doing this?

## Future Possibilities (Optional)
<!--What do you think this project could become? Delete if not needed.-->
Some possible points could be:
- This is the backend portion of #12

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Test `CommonsControllerTests.java`

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ x Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
#12
