### PR TITLE
Added UX Features to Leadboard Page 

### DIFF
--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -1,8 +1,7 @@
 import OurTable from "main/components/OurTable";
-import { hasRole } from "main/utils/currentUser";
 
 // should take in a players list from a commons
-export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
+export default function LeaderboardTable({ leaderboardUsers }) {
 
     const USD = new Intl.NumberFormat("en-US", {
         style: "currency",
@@ -11,11 +10,7 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
 
     const columns = [
         {
-            Header: 'User Id',
-            accessor: 'userId', 
-        },
-        {
-            Header: 'Username',
+            Header: 'Farmer',
             accessor: 'username', 
         },
         {
@@ -32,22 +27,42 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
         {
             Header: 'Cows Owned',
             accessor: 'numOfCows', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cow Health',
             accessor: 'cowHealth', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cows Bought',
             accessor: 'cowsBought', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cows Sold',
             accessor: 'cowsSold', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cow Deaths',
             accessor: 'cowDeaths', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
     ];
 
@@ -55,20 +70,9 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
 
     /* Temp filler for admin leaderboard table */
 
-    const columnsIfAdmin = [
-        {
-            Header: '(Admin) userCommons Id',
-            accessor: 'id'
-        },
-        ...columns
-
-    ];
-
-    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
-
     return <OurTable
         data={leaderboardUsers}
-        columns={columnsToDisplay}
+        columns={columns}
         testid={testid}
     />;
 

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -50,21 +50,23 @@ export default function LeaderboardPage() {
 
   const navigate = useNavigate();
 
+  
+
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
     <div data-testid={"LeaderboardPage-main-div"} style={{backgroundSize: 'cover', backgroundImage: `url(${Background})`}}>
         <BasicLayout>
             <div className="pt-2">
+                <Button onClick={() => navigate(-1)} data-testid="LeaderboardPage-back-button" style={{ float: "right" }} >
+                    Back
+                </Button>
                 <h1>Leaderboard</h1>
                 {
                   showLeaderboard?
                   (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser} />) :
                   (<p>You're not authorized to see the leaderboard.</p>)
                 }
-                </div>
-                <Button onClick={() => navigate(-1)} data-testid="LeaderboardPage-back-button" >
-                    Back
-                </Button>
+            </div>
         </BasicLayout>
     </div>
   )

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import LeaderboardTable from "main/components/Leaderboard/LeaderboardTable";
-import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import leaderboardFixtures from "fixtures/leaderboardFixtures";
 
 const mockedNavigate = jest.fn();

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -16,7 +16,6 @@ describe("LeaderboardTable tests", () => {
   const queryClient = new QueryClient();
 
   test("renders without crashing for empty table with user not logged in", () => {
-    const currentUser = null;
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -28,7 +27,6 @@ describe("LeaderboardTable tests", () => {
     );
   });
   test("renders without crashing for empty table for ordinary user", () => {
-    const currentUser = currentUserFixtures.userOnly;
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -41,7 +39,6 @@ describe("LeaderboardTable tests", () => {
   });
 
   test("renders without crashing for empty table for admin", () => {
-    const currentUser = currentUserFixtures.adminUser;
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -54,7 +51,6 @@ describe("LeaderboardTable tests", () => {
   });
 
   test("Has the expected column headers and content for adminUser", () => {
-    const currentUser = currentUserFixtures.adminUser;
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -93,7 +89,6 @@ describe("LeaderboardTable tests", () => {
   });
 
   test("Table is formatted correctly", () => {
-    const currentUser = currentUserFixtures.adminUser;
 
     render(
       <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -98,7 +98,7 @@ describe("LeaderboardTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={leaderboardFixtures.fiveUserCommonsLB} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={leaderboardFixtures.fiveUserCommonsLB} />
         </MemoryRouter>
       </QueryClientProvider>
 

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -65,8 +65,8 @@ describe("LeaderboardTable tests", () => {
 
     );
 
-    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health', 'Cows Bought', 'Cows Sold', 'Cow Deaths'];
-    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth', 'cowsBought', 'cowsSold', 'cowDeaths'];
+    const expectedHeaders = ['Farmer', 'Total Wealth', 'Cows Owned', 'Cow Health', 'Cows Bought', 'Cows Sold', 'Cow Deaths'];
+    const expectedFields = ['username', 'totalWealth','numOfCows', 'cowHealth', 'cowsBought', 'cowsSold', 'cowDeaths'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -79,15 +79,11 @@ describe("LeaderboardTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-userId`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-username`)).toHaveTextContent("one");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("$1,000.00");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsBought`)).toHaveTextContent("8");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsSold`)).toHaveTextContent("8");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowDeaths`)).toHaveTextContent("8");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-userId`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-username`)).toHaveTextContent("two");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("$1,000.00");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-cowsBought`)).toHaveTextContent("5");
@@ -96,19 +92,25 @@ describe("LeaderboardTable tests", () => {
 
   });
 
-  test("Total wealth is formatted correctly", () => {
+  test("Table is formatted correctly", () => {
     const currentUser = currentUserFixtures.adminUser;
 
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={leaderboardFixtures.threeUserCommonsLB} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={leaderboardFixtures.fiveUserCommonsLB} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
     );
 
     expect(screen.getAllByText("$1,000.00")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("100")[3]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("93")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("8")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("5")[1]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("1000")[2]).toHaveStyle("text-align: right;");
+    
 
   });
     

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -21,7 +21,7 @@ describe("LeaderboardTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={[]} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={[]} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -33,7 +33,7 @@ describe("LeaderboardTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={[]} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={[]} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -46,7 +46,7 @@ describe("LeaderboardTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={[]} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={[]} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -59,7 +59,7 @@ describe("LeaderboardTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={leaderboardFixtures.threeUserCommonsLB} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={leaderboardFixtures.threeUserCommonsLB} />
         </MemoryRouter>
       </QueryClientProvider>
 

--- a/frontend/src/tests/pages/LeaderboardPage.test.js
+++ b/frontend/src/tests/pages/LeaderboardPage.test.js
@@ -81,6 +81,7 @@ describe("LeaderboardPage tests", () => {
         const leaderboard_back_button = screen.getByTestId("LeaderboardPage-back-button");
         expect(leaderboard_main_div).toHaveAttribute("style","background-size: cover; background-image: url(PlayPageBackground.png);");
         expect(leaderboard_back_button).toBeInTheDocument();
+        expect(leaderboard_back_button).toHaveAttribute("style", "float: right;");
     });
 
     test("that navigate(-1) is called when Back is clicked", async () => {


### PR DESCRIPTION
## Overview
Changed the location of the back button on the leaderboard page from the bottom to the top right. Then removed the two columns that were labeled userCommonsID and User ID. Also changed the header for username to Farmer. Finally made all the following column's data right justified - (Cows Owned, Cow Health, Cows Bought, Cows Sold, and Cow Deaths).

## Screenshots (Optional)
<img width="1511" alt="Screenshot 2023-11-16 at 2 52 54 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-4/assets/54284148/96b8abe1-8ad4-403f-a5dd-2bce89df3592">


Closes #19 
