### PR TITLE
FEATURE: Frontend for default values for Commonds fields in application.properties / env variables

### DIFF
--- a/frontend/src/fixtures/commonsFixtures.js
+++ b/frontend/src/fixtures/commonsFixtures.js
@@ -72,6 +72,26 @@ const commonsFixtures = {
                 "aboveCapacityHealthUpdateStrategy": "Linear"
             }
         ],
+        defaultCommons:
+        [
+            {
+                "id": 1,
+                "name": "",
+                "day": 1,
+                "startingDate": "2025-03-05T15:50:10",
+                "startingBalance": 10000,
+                "totalPlayers": 100,
+                "cowPrice": 100,
+                "milkPrice": 1,
+                "degradationRate": .001,
+                "showLeaderboard": true,
+                "capacityPerUser": 1,
+                "carryingCapacity": 100,
+                "effectiveCapacity": 100,
+                "belowCapacityHealthUpdateStrategy": "Constant",
+                "aboveCapacityHealthUpdateStrategy": "Linear"
+            }
+        ],
 
     sevenCommons: [
         {

--- a/frontend/src/fixtures/commonsFixtures.js
+++ b/frontend/src/fixtures/commonsFixtures.js
@@ -72,26 +72,26 @@ const commonsFixtures = {
                 "aboveCapacityHealthUpdateStrategy": "Linear"
             }
         ],
-        defaultCommons:
-        [
-            {
-                "id": 1,
-                "name": "",
-                "day": 1,
-                "startingDate": "2025-03-05T15:50:10",
-                "startingBalance": 10000,
-                "totalPlayers": 100,
-                "cowPrice": 100,
-                "milkPrice": 1,
-                "degradationRate": .001,
-                "showLeaderboard": true,
-                "capacityPerUser": 1,
-                "carryingCapacity": 100,
-                "effectiveCapacity": 100,
-                "belowCapacityHealthUpdateStrategy": "Constant",
-                "aboveCapacityHealthUpdateStrategy": "Linear"
-            }
-        ],
+    defaultCommons:
+    [
+        {
+            "id": 1,
+            "name": "",
+            "day": 1,
+            "startingDate": "2025-03-05T15:50:10",
+            "startingBalance": 10000,
+            "totalPlayers": 100,
+            "cowPrice": 100,
+            "milkPrice": 1,
+            "degradationRate": .001,
+            "showLeaderboard": true,
+            "capacityPerUser": 1,
+            "carryingCapacity": 100,
+            "effectiveCapacity": 100,
+            "belowCapacityHealthUpdateStrategy": "Constant",
+            "aboveCapacityHealthUpdateStrategy": "Linear"
+        }
+    ],
 
     sevenCommons: [
         {

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -55,6 +55,10 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
 
     const curr = new Date();
     const today = curr.toISOString().split('T')[0];
+    const DefaultVals = {
+        name: "",
+        startingDate: today,
+    };
 
     return (
         <Form onSubmit={handleSubmit(submitAction)}>

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -97,7 +97,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                         <Form.Label htmlFor="name">Commons Name</Form.Label>
                         <OverlayTrigger
                             placement="top"
-                            overlay={<Tooltip>Enter Name for a new common</Tooltip>}
+                            overlay={<Tooltip>This is the name farmers will see when joining the game.</Tooltip>}
                             delay='5'
                         >
                             <Form.Control
@@ -119,7 +119,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                         <Form.Label htmlFor="startingBalance">Starting Balance</Form.Label>
                         <OverlayTrigger
                             placement="top"
-                            overlay={<Tooltip>Unit: $</Tooltip>}
+                            overlay={<Tooltip>Each farmer starts with this amount of money in dollars.</Tooltip>}
                             delay='100'
                         >
                             <Form.Control
@@ -149,7 +149,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                         <Form.Label htmlFor="cowPrice">Cow Price</Form.Label>
                         <OverlayTrigger
                             placement="top"
-                            overlay={<Tooltip>Unit: $</Tooltip>}
+                            overlay={<Tooltip>This is the price to purchase cows. The selling price is this amount times the health of the cows on that farm.</Tooltip>}
                             delay='100'
                         >
                             <Form.Control
@@ -179,7 +179,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                         <Form.Label htmlFor="milkPrice">Milk Price</Form.Label>
                         <OverlayTrigger
                             placement="top"
-                            overlay={<Tooltip>Unit: $</Tooltip>}
+                            overlay={<Tooltip>This is the amount of money the farmer earns in profits for each cow every time it is milked if it is at 100% health. When a cow is at health less than 100%, the amount earned is multiplied by that percentage (e.g. 75% of the milk price if the health is at 75%.</Tooltip>}
                             delay='100'
                         >
                             <Form.Control
@@ -209,6 +209,11 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                 <Col md={4}>
                     <Form.Group className="mb-3">
                         <Form.Label htmlFor="degradationRate">Degradation Rate</Form.Label>
+                        <OverlayTrigger
+                            placement="top"
+                            overlay={<Tooltip>This number controls the rate at which cow health decreases when the number of cows in the commons is greater than the effective carrying capacity. The way in which the number is used depends on the selected Health Update Formulas below.</Tooltip>}
+                            delay='100'
+                        >
                         <Form.Control
                             data-testid={`${testid}-degradationRate`}
                             id="degradationRate"
@@ -223,6 +228,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                                 min: {value: 0, message: "Degradation rate must be ≥ 0"},
                             })}
                         />
+                        </OverlayTrigger>
                         <Form.Control.Feedback type="invalid">
                             {errors.degradationRate?.message}
                         </Form.Control.Feedback>
@@ -231,6 +237,11 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                 <Col md={4}>
                     <Form.Group className="mb-3">
                         <Form.Label htmlFor="carryingCapacity">Carrying Capacity</Form.Label>
+                        <OverlayTrigger
+                            placement="top"
+                            overlay={<Tooltip>This is the minimum carrying capacity for the commons; at least this many cows may graze in the commons regardless of the number of players. If this number is zero, then only the Capacity Per User is used to determine the actual carrying capacity.</Tooltip>}
+                            delay='100'
+                        >
                         <Form.Control
                             data-testid={`${testid}-carryingCapacity`}
                             id="carryingCapacity"
@@ -244,6 +255,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                                 min: {value: 1, message: "Carrying Capacity must be ≥ 1"},
                             })}
                         />
+                        </OverlayTrigger>
                         <Form.Control.Feedback type="invalid">
                             {errors.carryingCapacity?.message}
                         </Form.Control.Feedback>
@@ -252,6 +264,11 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                 <Col md={4}>
                     <Form.Group className="mb-3">
                         <Form.Label htmlFor="capacityPerUser">Capacity Per User</Form.Label>
+                        <OverlayTrigger
+                            placement="top"
+                            overlay={<Tooltip>When this number is greater than zero, the commons will be able to support at least this many cows per farmer; that is, the effective carrying capacity of the commons is the value of Carrying Capacity, or Capacity Per User times the number of Farmers, whichever is greater. If this number is zero, then the Carrying Capacity is fixed regardless of the number of users.</Tooltip>}
+                            delay='100'
+                        >
                         <Form.Control
                             data-testid={`${testid}-capacityPerUser`}
                             id="capacityPerUser"
@@ -264,6 +281,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                                 required: "Capacity Per User is required",
                             })}
                         />
+                        </OverlayTrigger>
                         <Form.Control.Feedback type="invalid">
                             {errors.capacityPerUser?.message}
                         </Form.Control.Feedback>
@@ -274,6 +292,11 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
 
             <Form.Group className="mb-5" style={{width: '300px', height: '50px'}} data-testid={`${testid}-r3`}>
                 <Form.Label htmlFor="startingDate">Starting Date</Form.Label>
+                <OverlayTrigger
+                            placement="top"
+                            overlay={<Tooltip>This is the starting date of the game; before this date, the jobs to calculate statistics, milk the cows, and report profits, etc. will not be run on this commons.</Tooltip>}
+                            delay='100'
+                >
                 <Form.Control
                     data-testid={`${testid}-startingDate`}
                     id="startingDate"
@@ -285,6 +308,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                         validate: {isPresent: (v) => !isNaN(v)},
                     })}
                 />
+                </OverlayTrigger>
                 <Form.Control.Feedback type="invalid">
                     {errors.startingDate?.message}
                 </Form.Control.Feedback>
@@ -319,12 +343,18 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
 
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="showLeaderboard">Show Leaderboard?</Form.Label>
+                <OverlayTrigger
+                            placement="top"
+                            overlay={<Tooltip>When checked, regular users will have access to the leaderboard for this commons. When unchecked, only admins can see the leaderboard for this commons.</Tooltip>}
+                            delay='100'
+                >
                 <Form.Check
                     data-testid={`${testid}-showLeaderboard`}
                     type="checkbox"
                     id="showLeaderboard"
                     {...register("showLeaderboard")}
                 />
+                </OverlayTrigger>
             </Form.Group>
             <Row className="mb-5">
                 <Button type="submit"

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -296,7 +296,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                     <HealthUpdateStrategiesDropdown
                         formName={"aboveCapacityHealthUpdateStrategy"}
                         displayName={"When above capacity"}
-                        initialValue={defaults?.belowCapacityHealthUpdateStrategy}
+                        initialValue={defaults?.aboveCapacityHealthUpdateStrategy}
                         register={register}
                         healthUpdateStrategies={healthUpdateStrategies}
                     />

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -17,6 +17,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
         register,
         formState: {errors},
         handleSubmit,
+        reset,
     } = useForm(
         // modifiedCommons is guaranteed to be defined (initialCommons or {})
         {defaultValues: modifiedCommons}

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -34,8 +34,8 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     const curr = new Date();
     const today = curr.toISOString().split('T')[0];
     const DefaultVals = {
-        name: "", startingBalance: "10000", cowPrice: "100",
-        milkPrice: "1", degradationRate: 0.001, carryingCapacity: 100, startingDate: today
+        name: "", startingBalance: "20000", cowPrice: "200",
+        milkPrice: "2", degradationRate: 0.002, carryingCapacity: 200, startingDate: today
     };
 
     const belowStrategy = initialCommons?.belowCapacityStrategy || healthUpdateStrategies?.defaultBelowCapacity;

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -3,6 +3,7 @@ import {useForm} from "react-hook-form";
 import {useBackend} from "main/utils/useBackend";
 
 import HealthUpdateStrategiesDropdown from "main/components/Commons/HealthStrategiesUpdateDropdown";
+import { useEffect } from "react";
 
 function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     let modifiedCommons = initialCommons ? { ...initialCommons } : {};  // make a shallow copy of initialCommons
@@ -16,6 +17,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
         register,
         formState: {errors},
         handleSubmit,
+        setValue,
     } = useForm(
         // modifiedCommons is guaranteed to be defined (initialCommons or {})
         {defaultValues: modifiedCommons}
@@ -36,6 +38,22 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
         },
     );
 
+    useEffect(() => {
+        if (defaults) {
+            setValue("startingBalance", defaults.startingBalance);
+            setValue("cowPrice", defaults.cowPrice);
+            setValue("milkPrice", defaults.milkPrice);
+            setValue("degradationRate", defaults.degradationRate);
+            setValue("carryingCapacity", defaults.carryingCapacity);
+            setValue("capacityPerUser", defaults.capacityPerUser);
+            setValue("aboveCapacityHealthUpdateStrategy", defaults.aboveCapacityHealthUpdateStrategy);
+            setValue("belowCapacityHealthUpdateStrategy", defaults.belowCapacityHealthUpdateStrategy);
+        }
+    }, [defaults, setValue]);
+
+
+    console.log("defaults", defaults);
+
     const testid = "CommonsForm";
 
     const curr = new Date();
@@ -50,9 +68,6 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
         startingDate: today,
         capacityPerUser: 2
     };
-
-    const belowStrategy = initialCommons?.belowCapacityStrategy || healthUpdateStrategies?.defaultBelowCapacity;
-    const aboveStrategy = initialCommons?.aboveCapacityStrategy || healthUpdateStrategies?.defaultAboveCapacity;
 
     return (
         <Form onSubmit={handleSubmit(submitAction)}>
@@ -138,7 +153,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                                 id="cowPrice"
                                 type="number"
                                 step="0.01"
-                                defaultValue={DefaultVals.cowPrice}
+                                defaultValue={defaults?.cowPrice}
                                 isInvalid={!!errors.cowPrice}
                                 {...register("cowPrice", {
                                     valueAsNumber: true,
@@ -168,7 +183,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                                 id="milkPrice"
                                 type="number"
                                 step="0.01"
-                                defaultValue={DefaultVals.milkPrice}
+                                defaultValue={defaults?.milkPrice}
                                 isInvalid={!!errors.milkPrice}
                                 {...register("milkPrice", {
                                     valueAsNumber: true,
@@ -195,7 +210,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                             id="degradationRate"
                             type="number"
                             step="0.0001"
-                            defaultValue={DefaultVals.degradationRate}
+                            defaultValue={defaults?.degradationRate}
 
                             isInvalid={!!errors.degradationRate}
                             {...register("degradationRate", {
@@ -217,7 +232,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                             id="carryingCapacity"
                             type="number"
                             step="1"
-                            defaultValue={DefaultVals.carryingCapacity}
+                            defaultValue={defaults?.carryingCapacity}
                             isInvalid={!!errors.carryingCapacity}
                             {...register("carryingCapacity", {
                                 valueAsNumber: true,
@@ -238,7 +253,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                             id="capacityPerUser"
                             type="number"
                             step="1"
-                            defaultValue={DefaultVals.capacityPerUser}
+                            defaultValue={defaults?.capacityPerUser}
                             isInvalid={!!errors.capacityPerUser}
                             {...register("capacityPerUser", {
                                 valueAsNumber: true,
@@ -281,7 +296,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                     <HealthUpdateStrategiesDropdown
                         formName={"aboveCapacityHealthUpdateStrategy"}
                         displayName={"When above capacity"}
-                        initialValue={aboveStrategy}
+                        initialValue={defaults?.belowCapacityHealthUpdateStrategy}
                         register={register}
                         healthUpdateStrategies={healthUpdateStrategies}
                     />
@@ -291,7 +306,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                     <HealthUpdateStrategiesDropdown
                         formName={"belowCapacityHealthUpdateStrategy"}
                         displayName={"When below capacity"}
-                        initialValue={belowStrategy}
+                        initialValue={defaults?.belowCapacityHealthUpdateStrategy}
                         register={register}
                         healthUpdateStrategies={healthUpdateStrategies}
                     />

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -214,20 +214,20 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                             overlay={<Tooltip>This number controls the rate at which cow health decreases when the number of cows in the commons is greater than the effective carrying capacity. The way in which the number is used depends on the selected Health Update Formulas below.</Tooltip>}
                             delay='100'
                         >
-                        <Form.Control
-                            data-testid={`${testid}-degradationRate`}
-                            id="degradationRate"
-                            type="number"
-                            step="0.0001"
-                            defaultValue={defaults?.degradationRate}
+                            <Form.Control
+                                data-testid={`${testid}-degradationRate`}
+                                id="degradationRate"
+                                type="number"
+                                step="0.0001"
+                                defaultValue={defaults?.degradationRate}
 
-                            isInvalid={!!errors.degradationRate}
-                            {...register("degradationRate", {
-                                valueAsNumber: true,
-                                required: "Degradation rate is required",
-                                min: {value: 0, message: "Degradation rate must be ≥ 0"},
-                            })}
-                        />
+                                isInvalid={!!errors.degradationRate}
+                                {...register("degradationRate", {
+                                    valueAsNumber: true,
+                                    required: "Degradation rate is required",
+                                    min: {value: 0, message: "Degradation rate must be ≥ 0"},
+                                })}
+                            />
                         </OverlayTrigger>
                         <Form.Control.Feedback type="invalid">
                             {errors.degradationRate?.message}
@@ -242,19 +242,19 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                             overlay={<Tooltip>This is the minimum carrying capacity for the commons; at least this many cows may graze in the commons regardless of the number of players. If this number is zero, then only the Capacity Per User is used to determine the actual carrying capacity.</Tooltip>}
                             delay='100'
                         >
-                        <Form.Control
-                            data-testid={`${testid}-carryingCapacity`}
-                            id="carryingCapacity"
-                            type="number"
-                            step="1"
-                            defaultValue={defaults?.carryingCapacity}
-                            isInvalid={!!errors.carryingCapacity}
-                            {...register("carryingCapacity", {
-                                valueAsNumber: true,
-                                required: "Carrying capacity is required",
-                                min: {value: 1, message: "Carrying Capacity must be ≥ 1"},
-                            })}
-                        />
+                            <Form.Control
+                                data-testid={`${testid}-carryingCapacity`}
+                                id="carryingCapacity"
+                                type="number"
+                                step="1"
+                                defaultValue={defaults?.carryingCapacity}
+                                isInvalid={!!errors.carryingCapacity}
+                                {...register("carryingCapacity", {
+                                    valueAsNumber: true,
+                                    required: "Carrying capacity is required",
+                                    min: {value: 1, message: "Carrying Capacity must be ≥ 1"},
+                                })}
+                            />
                         </OverlayTrigger>
                         <Form.Control.Feedback type="invalid">
                             {errors.carryingCapacity?.message}
@@ -269,18 +269,18 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                             overlay={<Tooltip>When this number is greater than zero, the commons will be able to support at least this many cows per farmer; that is, the effective carrying capacity of the commons is the value of Carrying Capacity, or Capacity Per User times the number of Farmers, whichever is greater. If this number is zero, then the Carrying Capacity is fixed regardless of the number of users.</Tooltip>}
                             delay='100'
                         >
-                        <Form.Control
-                            data-testid={`${testid}-capacityPerUser`}
-                            id="capacityPerUser"
-                            type="number"
-                            step="1"
-                            defaultValue={defaults?.capacityPerUser}
-                            isInvalid={!!errors.capacityPerUser}
-                            {...register("capacityPerUser", {
-                                valueAsNumber: true,
-                                required: "Capacity Per User is required",
-                            })}
-                        />
+                            <Form.Control
+                                data-testid={`${testid}-capacityPerUser`}
+                                id="capacityPerUser"
+                                type="number"
+                                step="1"
+                                defaultValue={defaults?.capacityPerUser}
+                                isInvalid={!!errors.capacityPerUser}
+                                {...register("capacityPerUser", {
+                                    valueAsNumber: true,
+                                    required: "Capacity Per User is required",
+                                })}
+                            />
                         </OverlayTrigger>
                         <Form.Control.Feedback type="invalid">
                             {errors.capacityPerUser?.message}
@@ -297,17 +297,17 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                             overlay={<Tooltip>This is the starting date of the game; before this date, the jobs to calculate statistics, milk the cows, and report profits, etc. will not be run on this commons.</Tooltip>}
                             delay='100'
                 >
-                <Form.Control
-                    data-testid={`${testid}-startingDate`}
-                    id="startingDate"
-                    type="date"
-                    defaultValue={DefaultVals.startingDate}
-                    isInvalid={!!errors.startingDate}
-                    {...register("startingDate", {
-                        valueAsDate: true,
-                        validate: {isPresent: (v) => !isNaN(v)},
-                    })}
-                />
+                    <Form.Control
+                        data-testid={`${testid}-startingDate`}
+                        id="startingDate"
+                        type="date"
+                        defaultValue={DefaultVals.startingDate}
+                        isInvalid={!!errors.startingDate}
+                        {...register("startingDate", {
+                            valueAsDate: true,
+                            validate: {isPresent: (v) => !isNaN(v)},
+                        })}
+                    />
                 </OverlayTrigger>
                 <Form.Control.Feedback type="invalid">
                     {errors.startingDate?.message}
@@ -348,12 +348,12 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                             overlay={<Tooltip>When checked, regular users will have access to the leaderboard for this commons. When unchecked, only admins can see the leaderboard for this commons.</Tooltip>}
                             delay='100'
                 >
-                <Form.Check
-                    data-testid={`${testid}-showLeaderboard`}
-                    type="checkbox"
-                    id="showLeaderboard"
-                    {...register("showLeaderboard")}
-                />
+                    <Form.Check
+                        data-testid={`${testid}-showLeaderboard`}
+                        type="checkbox"
+                        id="showLeaderboard"
+                        {...register("showLeaderboard")}
+                    />
                 </OverlayTrigger>
             </Form.Group>
             <Row className="mb-5">

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -17,7 +17,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
         register,
         formState: {errors},
         handleSubmit,
-        setValue,
+        reset,
     } = useForm(
         // modifiedCommons is guaranteed to be defined (initialCommons or {})
         {defaultValues: modifiedCommons}
@@ -40,16 +40,29 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
 
     useEffect(() => {
         if (defaults && !initialCommons) {
-            setValue("startingBalance", defaults.startingBalance);
-            setValue("cowPrice", defaults.cowPrice);
-            setValue("milkPrice", defaults.milkPrice);
-            setValue("degradationRate", defaults.degradationRate);
-            setValue("carryingCapacity", defaults.carryingCapacity);
-            setValue("capacityPerUser", defaults.capacityPerUser);
-            setValue("aboveCapacityHealthUpdateStrategy", defaults.aboveCapacityHealthUpdateStrategy);
-            setValue("belowCapacityHealthUpdateStrategy", defaults.belowCapacityHealthUpdateStrategy);
+            const {
+                startingBalance,
+                cowPrice,
+                milkPrice,
+                degradationRate,
+                carryingCapacity,
+                capacityPerUser,
+                aboveCapacityHealthUpdateStrategy,
+                belowCapacityHealthUpdateStrategy
+            } = defaults;
+            
+            reset({
+                startingBalance,
+                cowPrice,
+                milkPrice,
+                degradationRate,
+                carryingCapacity,
+                capacityPerUser,
+                aboveCapacityHealthUpdateStrategy,
+                belowCapacityHealthUpdateStrategy
+            });
         }
-    }, [defaults, setValue]);
+    }, [defaults, initialCommons, reset]);
 
     const testid = "CommonsForm";
 

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -39,7 +39,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     );
 
     useEffect(() => {
-        if (defaults) {
+        if (defaults && !initialCommons) {
             setValue("startingBalance", defaults.startingBalance);
             setValue("cowPrice", defaults.cowPrice);
             setValue("milkPrice", defaults.milkPrice);
@@ -51,23 +51,10 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
         }
     }, [defaults, setValue]);
 
-
-    console.log("defaults", defaults);
-
     const testid = "CommonsForm";
 
     const curr = new Date();
     const today = curr.toISOString().split('T')[0];
-    const DefaultVals = {
-        name: "",
-        startingBalance: "20000",
-        cowPrice: "200",
-        milkPrice: "2",
-        degradationRate: 0.002,
-        carryingCapacity: 200,
-        startingDate: today,
-        capacityPerUser: 2
-    };
 
     return (
         <Form onSubmit={handleSubmit(submitAction)}>

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -29,13 +29,26 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
         },
     );
 
+    const {data: defaults} = useBackend(
+        "/api/commons/defaults", {
+            method: "GET",
+            url: "/api/commons/defaults",
+        },
+    );
+
     const testid = "CommonsForm";
 
     const curr = new Date();
     const today = curr.toISOString().split('T')[0];
     const DefaultVals = {
-        name: "", startingBalance: "20000", cowPrice: "200",
-        milkPrice: "2", degradationRate: 0.002, carryingCapacity: 200, startingDate: today
+        name: "",
+        startingBalance: "20000",
+        cowPrice: "200",
+        milkPrice: "2",
+        degradationRate: 0.002,
+        carryingCapacity: 200,
+        startingDate: today,
+        capacityPerUser: 2
     };
 
     const belowStrategy = initialCommons?.belowCapacityStrategy || healthUpdateStrategies?.defaultBelowCapacity;
@@ -95,7 +108,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                                 data-testid={`${testid}-startingBalance`}
                                 type="number"
                                 step="0.01"
-                                defaultValue={DefaultVals.startingBalance}
+                                defaultValue={defaults?.startingBalance}
                                 isInvalid={!!errors.startingBalance}
                                 {...register("startingBalance", {
                                     valueAsNumber: true,
@@ -225,6 +238,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
                             id="capacityPerUser"
                             type="number"
                             step="1"
+                            defaultValue={DefaultVals.capacityPerUser}
                             isInvalid={!!errors.capacityPerUser}
                             {...register("capacityPerUser", {
                                 valueAsNumber: true,

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -402,6 +402,8 @@ describe("CommonsForm tests", () => {
         url: "/api/commons/all-health-update-strategies",
       },
       );
+    });
+    await waitFor(() => {
       expect(useBackendSpy).toHaveBeenCalledWith(
         "/api/commons/defaults", {
         method: "GET",

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -283,6 +283,13 @@ describe("CommonsForm tests", () => {
   });
 
   it("renders correctly when an initialCommons is not passed in", async () => {
+    const curr = new Date();
+    const today = curr.toISOString().substr(0, 10);
+    const DefaultVals = {
+      name: "", startingBalance: 10000, cowPrice: 100,
+      milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today,
+      aboveCapacityHealthUpdateStrategy: "Linear", belowCapacityHealthUpdateStrategy: "Constant"
+    };
 
     axiosMock
       .onGet("/api/commons/all-health-update-strategies")
@@ -290,7 +297,7 @@ describe("CommonsForm tests", () => {
     
     axiosMock
       .onGet("/api/commons/defaults")
-      .reply(200, commonsFixtures.defaultCommons[0]);
+      .reply(200, DefaultVals);
 
     render(
       <QueryClientProvider client={new QueryClient()}>
@@ -298,6 +305,17 @@ describe("CommonsForm tests", () => {
           <CommonsForm />
         </Router>
       </QueryClientProvider>
+    );
+
+    expect(await screen.findByTestId("CommonsForm-name")).toBeInTheDocument();
+    [
+      "name", "degradationRate", "carryingCapacity",
+      "milkPrice","cowPrice","startingBalance","startingDate",
+    ].forEach(
+        (item) => {
+          const element = screen.getByTestId(`CommonsForm-${item}`);
+          expect(element).toHaveValue(DefaultVals[item]);
+        }
     );
 
     expect(await screen.findByText(/When below capacity/)).toBeInTheDocument();
@@ -313,6 +331,10 @@ describe("CommonsForm tests", () => {
     axiosMock
       .onGet("/api/commons/all-health-update-strategies")
       .reply(200, healthUpdateStrategyListFixtures.real);
+    
+    axiosMock
+      .onGet("/api/commons/defaults")
+      .reply(200, commonsFixtures.defaultCommons);
 
     // https://www.chakshunyu.com/blog/how-to-spy-on-a-named-import-in-jest/
     const useBackendSpy = jest.spyOn(useBackendModule, 'useBackend');
@@ -330,6 +352,12 @@ describe("CommonsForm tests", () => {
         "/api/commons/all-health-update-strategies", {
         method: "GET",
         url: "/api/commons/all-health-update-strategies",
+      },
+      );
+      expect(useBackendSpy).toHaveBeenCalledWith(
+        "/api/commons/defaults", {
+        method: "GET",
+        url: "/api/commons/defaults",
       },
       );
     });

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -160,6 +160,10 @@ describe("CommonsForm tests", () => {
         .onGet("/api/commons/all-health-update-strategies")
         .reply(200, healthUpdateStrategyListFixtures.real);
 
+    axiosMock
+      .onGet("/api/commons/defaults")
+      .reply(200, DefaultVals);
+
     render(
         <QueryClientProvider client={new QueryClient()}>
           <Router>
@@ -283,6 +287,10 @@ describe("CommonsForm tests", () => {
     axiosMock
       .onGet("/api/commons/all-health-update-strategies")
       .reply(200, healthUpdateStrategyListFixtures.real);
+    
+    axiosMock
+      .onGet("/api/commons/defaults")
+      .reply(200, commonsFixtures.defaultCommons[0]);
 
     render(
       <QueryClientProvider client={new QueryClient()}>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,7 +38,7 @@ app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 0 4 * * *}}
 app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0,6,12,18 * * *}}
 spring.jackson.time-zone=America/Los_Angeles
 
-app.commons.default.startingBalance=${HAPPYCOWS_STARTING_BALANCE:${env.HAPPYCOWS_STARTING_BALANCE:1000}}
+app.commons.default.startingBalance=${HAPPYCOWS_STARTING_BALANCE:${env.HAPPYCOWS_STARTING_BALANCE:10000}}
 app.commons.default.cowPrice=${HAPPYCOWS_COW_PRICE:${env.HAPPYCOWS_COW_PRICE:100}}
 app.commons.default.milkPrice=${HAPPYCOWS_MILK_PRICE:${env.HAPPYCOWS_MILK_PRICE:1}}
 app.commons.default.degradationRate=${HAPPYCOWS_DEGRADATION_RATE:${env.HAPPYCOWS_DEGRADATION_RATE:0.001}}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -1242,7 +1242,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test
     public void getDefaultsTest() throws Exception {
         Commons commons = Commons.builder()
-                                        .startingBalance(1000)
+                                        .startingBalance(10000)
                                         .cowPrice(100)
                                         .milkPrice(1)
                                         .degradationRate(0.001)


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
Show default values set in application.properties / .env on CommonsCreate page form.

## Future Possibilities (Optional)
<!--What do you think this project could become? Delete if not needed.-->
Some possible points could be:
- Possibly include some sort of validation for default values? (another student mentioned this in the happycows slack channel)

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run project
3. Navigate to Commons Create page
4. Modify application.properties / .env
5. Reload and notice that default values have changed
6. Submit and note that the default values are passed into the new commons that was just created

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #12 
