### PR TITLE
Refactor CommonList Component To Have Default UI

### DIFF
--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -30,8 +30,7 @@ const CommonsList = (props) => {
                     </Row>
                 </Container>
             </Card.Subtitle>
-            {
-                props.commonList &&
+            {props.commonList &&
                 props.commonList.map(
                     (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} />)
                 )

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -30,7 +30,8 @@ const CommonsList = (props) => {
                     </Row>
                 </Container>
             </Card.Subtitle>
-            {props.commonList &&
+            {
+                props.commonList &&
                 props.commonList.map(
                     (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} />)
                 )

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -71,13 +71,13 @@ export default function HomePage({hour=null}) {
             <Col sm>
               <CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} />
               {
-                commonsJoined.length == 0 ? <p>Currently, there are no commons available</p> : null 
+                commonsJoined.length === 0 ? <p>Currently, there are no commons available</p> : null 
               }
               </Col>
             <Col sm>
               <CommonsList commonList={commonsNotJoinedList} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} />
               {
-                commonsNotJoinedList.length == 0 ? <p><center>Currently, there are no commons available</center></p> : null 
+                commonsNotJoinedList.length === 0 ? <p><center>Currently, there are no commons available</center></p> : null 
               }
               </Col>
           </Row>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -60,7 +60,7 @@ export default function HomePage({hour=null}) {
 
   //create a list of commons that the user hasn't joined for use in the "Join a New Commons" list.
   const commonsNotJoinedList = commonsNotJoined(commons, commonsJoined);
-  
+
   // Stryker disable all : TODO: restructure this code to avoid the need for this disable
   return (
     <div data-testid={"HomePage-main-div"} style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
@@ -68,8 +68,18 @@ export default function HomePage({hour=null}) {
         <h1 data-testid="homePage-title" style={{ fontSize: "75px", borderRadius: "7px", backgroundColor: "white", opacity: ".9" }} className="text-center border-0 my-3">Howdy Farmer {firstName}</h1>
         <Container>
           <Row>
-            <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>
-            <Col sm><CommonsList commonList={commonsNotJoinedList} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
+            <Col sm>
+              <CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} />
+              {
+                commonsJoined.length == 0 ? <p>Currently, there are no commons available</p> : null 
+              }
+              </Col>
+            <Col sm>
+              <CommonsList commonList={commonsNotJoinedList} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} />
+              {
+                commonsNotJoinedList.length == 0 ? <p><center>Currently, there are no commons available</center></p> : null 
+              }
+              </Col>
           </Row>
         </Container>
       </BasicLayout>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -71,7 +71,7 @@ export default function HomePage({hour=null}) {
             <Col sm>
               <CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} />
               {
-                commonsJoined.length === 0 ? <p>Currently, there are no commons available</p> : null 
+                commonsJoined.length === 0 ? <p><center>Currently, there are no commons available</center></p> : null 
               }
               </Col>
             <Col sm>

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -52,6 +52,20 @@ describe("HomePage tests", () => {
         });
     });
 
+    test("renders with default when commons list when list is empty", async () => {
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/commons/all").reply(200, []);
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HomePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(screen.getByText("Currently, there are no commons available")).toBeInTheDocument();
+    });
+
     test("renders with default for commons when api times out", () => {
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/commons/all").timeout();


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we add a default UI when the common list is empty that says "Currently, there are no commons available" so users can better understand what is going on. 

## Screenshots
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
<img width="1352" alt="Screenshot 2023-11-26 at 11 27 32 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-4/assets/46696490/d2f882e0-b793-46e4-ae09-4613e86ed5cf">

<!--## Feedback Request
Anywhere specific you want reviewers to take a look at and give suggestions. Delete if not needed.
Please give suggestions on the following:
- This method might not be the best way to do things. What do you think?-->

## Validation 
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to the home page.
4. Test this function.

## Tests
<!--Add any additional tests or required tests-->
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #4 
