### PR TITLE
Add Background For The Default CommonsList UI

### DIFF
--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -71,13 +71,13 @@ export default function HomePage({hour=null}) {
             <Col sm>
               <CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} />
               {
-                commonsJoined.length === 0 ? <p><center>Currently, there are no commons available</center></p> : null 
+                commonsJoined.length === 0 ? <p style={{backgroundColor: "white", opacity: ".9"}}><center>Currently, there are no commons available</center></p> : null 
               }
               </Col>
             <Col sm>
               <CommonsList commonList={commonsNotJoinedList} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} />
               {
-                commonsNotJoinedList.length === 0 ? <p><center>Currently, there are no commons available</center></p> : null 
+                commonsNotJoinedList.length === 0 ? <p style={{backgroundColor: "white", opacity: ".9"}}><center>Currently, there are no commons available</center></p> : null 
               }
               </Col>
           </Row>


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we add a background for the default UI when the common list is empty.

## Screenshots
<img width="961" alt="Screenshot 2023-11-30 at 2 59 11 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-4/assets/46696490/e5b09ec1-e831-4c1c-bc63-8e95ab093ad0">

## Validation 
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to the Home page.
4. Test this function.

## Tests
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

<!--## Linked Issues
<!--Issues related to the PR-->
Closes #0-->
